### PR TITLE
Faster e2e test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,7 @@ def run(*args, returncode=0, obj=None, **kwargs):
     env = environ.copy()
     env['LAIN_IGNORE_LINT'] = 'false'
     obj = obj or {}
+    print(f"Invoke: {args} {kwargs.get('args', [])}")
     res = runner.invoke(*args, obj=obj, env=env, **kwargs)
     if returncode is not None:
         real_code = rc(res)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ from lain_cli.utils import (
     rc,
     tell_cluster_config,
     tell_registry_client,
+    yadu,
     yalo,
 )
 
@@ -233,7 +234,7 @@ def dummy(request):
         chdir(DUMMY_REPO)
 
     tear_down()
-    run(lain, args=['init'])
+    run_lain_init()
     # `lain secret show` will create a dummy secret
     run(lain, args=['secret', 'show'])
     request.addfinalizer(tear_down)
@@ -249,3 +250,13 @@ def dic_contains(big, small):
     left = big.copy()
     left.update(small)
     assert left == big
+
+
+def run_lain_init(*args, **kwargs):
+    """Run `lain init` and modify values to speed up tests."""
+    res = run(lain, args=['init'] + list(args), **kwargs)
+    # Speed up pod termination
+    values = load_dummy_values()
+    values['deployments']['web']['terminationGracePeriodSeconds'] = 1
+    yadu(values, DUMMY_VALUES_PATH)
+    return res

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -43,6 +43,7 @@ from tests.conftest import (
     TEST_CLUSTER_CONFIG,
     load_dummy_values,
     run,
+    run_lain_init,
     run_under_click_context,
     tell_deployed_images,
     tell_ing_name,
@@ -168,9 +169,9 @@ def test_build(registry):
 @pytest.mark.usefixtures('dummy')
 def test_workflow(registry):
     # lain init should failed when chart directory already exists
-    run(lain, args=['init'], returncode=1)
+    run_lain_init(returncode=1)
     # use -f to remove chart directory and redo
-    run(lain, args=['init', '-f'])
+    run_lain_init('-f')
     # lain use will switch current context switch to [TEST_CLUSTER]
     run(lain, args=['use', TEST_CLUSTER])
     # lain use will print current cluster


### PR DESCRIPTION
Change `terminationGracePeriodSeconds` of deployments to 1 after calling `lain init`.

This change speeds up the e2e test job from ~20 minutes to ~8m in our GitLab-CI environment.