### PR TITLE
[lain lint] give user appropriate docs url on error

### DIFF
--- a/lain_cli/lain.py
+++ b/lain_cli/lain.py
@@ -79,6 +79,7 @@ from lain_cli.utils import (
     kubectl_edit,
     lain_,
     lain_build,
+    lain_docs,
     lain_meta,
     make_canary_name,
     make_image_str,
@@ -557,8 +558,9 @@ def lint(ctx, simple):
 
     last_error = ctx.obj.get('last_error')
     if last_error:
-        debug(f'last error: {last_error}')
-        echo('', exit=1)
+        url = lain_docs('design.html#lain-resource-design')
+        echo('')
+        error(f'📖 learn about resource management: {url}', exit=1)
 
 
 @lain.command()

--- a/lain_cli/prometheus.py
+++ b/lain_cli/prometheus.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime, timedelta, timezone
+from math import ceil
 from statistics import StatisticsError, quantiles
 
 import click
@@ -8,11 +9,11 @@ from requests.exceptions import ReadTimeout
 
 from lain_cli.utils import (
     RequestClientMixin,
+    context,
     ensure_str,
     error,
     tell_cluster_config,
     warn,
-    context,
 )
 
 
@@ -59,7 +60,7 @@ class Prometheus(RequestClientMixin):
         cpu_result = self.query_cpu(appname, proc_name)
         # [{'metric': {}, 'value': [1595486084.053, '4.990567343235413']}]
         if cpu_result:
-            cpu_top_list = [int(float(p[-1])) for p in cpu_result[0]['values']]
+            cpu_top_list = [ceil(float(p[-1])) for p in cpu_result[0]['values']]
             cnt = len(cpu_top_list)
             if cpu_top_list.count(0) / cnt > 0.7:
                 accurate = False

--- a/lain_cli/utils.py
+++ b/lain_cli/utils.py
@@ -2942,4 +2942,13 @@ def tell_all_clusters():
     return ccs
 
 
+def lain_docs(path):
+    cc = tell_cluster_config()
+    sphinx_docs_url = (
+        cc.get('sphinx_docs_url') or 'https://lain-cli.readthedocs.io/en/latest'
+    )
+    url = join(sphinx_docs_url, path)
+    return url
+
+
 CLUSTERS = tell_all_clusters()


### PR DESCRIPTION
为了进一步提升易用性, 和文档可发现性, 今后 lain 会在合适的时候给出相关文档链接, 所有报错的地方, 如果有对应的文档可参考, 都会随着错误信息一并附上.

<img width="1053" alt="image" src="https://user-images.githubusercontent.com/4319104/156370837-546e5bd7-21ed-4ade-af29-b5d413726d0b.png">
