### PR TITLE
[lain delete] warn user when sc is not re-attachable

### DIFF
--- a/lain_cli/__init__.py
+++ b/lain_cli/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '4.10.41'
+__version__ = '4.10.42'
 package_name = 'lain'

--- a/lain_cli/utils.py
+++ b/lain_cli/utils.py
@@ -516,6 +516,19 @@ def delete_pod(selector, graceful=False):
         wait_for_pod_up(selector=selector)
 
 
+def storage_class_can_reattach(sc_name):
+    """this is an over-simplified check, if pvc name is not random, the
+    generated pv is deemed as re-attachable"""
+    res = kubectl('get', 'sc', '-ojson', sc_name, capture_output=True)
+    spec = jalo(res.stdout)
+    if spec.get('reclaimPolicy') != 'Retain':
+        return False
+    parameters = spec['parameters']
+    if 'pathPattern' in parameters:
+        return True
+    return False
+
+
 def update_canary_annotations(release_name, canary_group_name=None):
     """when calling with empty canary_group_name, will set canary-weight to 0%"""
     ctx = context()


### PR DESCRIPTION
经指点, 复用 pvc name 能实现卸载之后, 再次上线的时候进行 re-attach. 但当时 lain delete 的检查已经写出来了, 觉得还是有用的, 因为也许不是所有 sc 都能这么搞...

lain delete 的时候, 会对 sc 的参数做一些简单检查, 做个粗略判断, 然后提示用户要谨慎删.