### PR TITLE
Drop deprecated `use_deprecated_html5lib` argument

### DIFF
--- a/lain_cli/utils.py
+++ b/lain_cli/utils.py
@@ -2916,7 +2916,6 @@ def version_challenge():
     finder = PackageFinder.create(
         link_collector=link_collector,
         selection_prefs=selection_prefs,
-        use_deprecated_html5lib=False,
     )
     best_candidate = finder.find_best_candidate(package_name).best_candidate
     debug(f'best candidate: {best_candidate}')

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 from lain_cli import __version__, package_name
 
 requirements = [
-    'pip>=22.0',
+    'pip>=22.1',
     'ruamel.yaml>=0.17.10',
     'requests',
     'humanfriendly>=4.16.1',


### PR DESCRIPTION
Related PR: https://github.com/pypa/pip/pull/11259